### PR TITLE
Implement RFC3986 compatible encodeURIComponent

### DIFF
--- a/js/scripts.js
+++ b/js/scripts.js
@@ -61,7 +61,10 @@ function jwtDecode(){
 }
 
 function urlEncode(){
-    get('preUrlOutputCode').innerText = encodeURIComponent(get('textAreaUrlInput').value);
+    get('preUrlOutputCode').innerText = encodeURIComponent(get('textAreaUrlInput').value).replace(
+        /[!'()*]/g,
+        (c) => `%${c.charCodeAt(0).toString(16).toUpperCase()}`
+      );
 }
 
 function urlDecode(){


### PR DESCRIPTION
This PR implements a RFC3986 compatible encodeURIComponent as per the [spec](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/encodeURIComponent#encoding_for_rfc3986).
