### PR TITLE
Add offline Image Editor tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,12 +47,14 @@ Open `index.html` directly in any modern browser. No build step, no dependencies
 | **Timestamp** | Converts Unix timestamps (seconds/milliseconds) to human-readable dates and vice versa |
 | **HTTP Status** | Searchable reference table of HTTP status codes (1xx–5xx) |
 | **CORS Builder** | Generates `Access-Control-*` response headers from a guided form |
+| **Image Editor** | Redact (solid fill), pixelate, annotate (box/arrow/pen/text), crop, resize and export screenshots (PNG/JPEG/WebP) fully client-side; load via file, drag-drop or clipboard paste; EXIF stripped on export |
 
 ## Technical Notes
 
 - **No external API calls** — all processing happens in the browser
 - **Crypto** — hashing uses the Web Crypto API (`crypto.subtle.digest`); passwords and UUIDs use `crypto.getRandomValues` / `crypto.randomUUID()`
 - **SAML** — decompression uses `DecompressionStream('deflate-raw')` (Chrome 80+, Firefox 113+, Safari 16.4+)
+- **Image Editor** — `<canvas>` + Pointer Events, no libraries; redaction and pixelation are baked into the bitmap (not recoverable overlays); EXIF is dropped because the image is re-encoded through canvas on export; large images auto-downscale to 4000px; clipboard image copy needs `ClipboardItem` (Chromium), Download always works
 - **Theming** — dark mode by default; light mode toggle persisted in `localStorage`
 - **Fonts** — [Inter](https://fonts.google.com/specimen/Inter) (UI) and [Material Symbols Outlined](https://fonts.google.com/icons) (icons)
 

--- a/app.js
+++ b/app.js
@@ -869,3 +869,454 @@ document.getElementById('regex-pattern').addEventListener('input', regexTest);
 document.getElementById('regex-test').addEventListener('input', regexTest);
 // Init HTTP table on load
 renderHttpTable('');
+
+/* ══════════════════════════════════════════════════════════════
+   Image Editor
+   Fully client-side: redact, annotate, crop, resize, export.
+   Undo/redo via base-canvas snapshots. Redaction is baked into
+   the bitmap on commit (destructive) so it can never leak.
+   ══════════════════════════════════════════════════════════════ */
+const img = {
+  canvas: null, ctx: null,
+  base: null,            // offscreen canvas holding committed pixels
+  history: [], hi: -1,   // ImageData snapshots + index
+  tool: 'redact',
+  color: '#ff3b30',
+  stroke: 6,
+  pixel: 14,
+  drawing: false,
+  start: null,
+  penPts: [],
+  cropRect: null,
+};
+const IMG_MAX_LOAD = 4000;   // downscale larger images on load
+const IMG_MAX_DIM = 8000;    // hard cap for manual resize
+const IMG_HISTORY = 12;      // snapshot cap (memory guard)
+
+function imgEl(id) { return document.getElementById(id); }
+
+function imgHumanSize(n) {
+  return n < 1024 ? n + ' B'
+    : n < 1048576 ? (n / 1024).toFixed(1) + ' KB'
+    : (n / 1048576).toFixed(2) + ' MB';
+}
+
+function imgPos(e) {
+  const r = img.canvas.getBoundingClientRect();
+  return {
+    x: (e.clientX - r.left) * (img.canvas.width / r.width),
+    y: (e.clientY - r.top) * (img.canvas.height / r.height),
+  };
+}
+
+function imgNormRect(a, b) {
+  return { x: Math.min(a.x, b.x), y: Math.min(a.y, b.y), w: Math.abs(a.x - b.x), h: Math.abs(a.y - b.y) };
+}
+
+/* ── Rendering ── */
+function imgRenderBase() {
+  if (!img.base) return;
+  img.ctx.clearRect(0, 0, img.canvas.width, img.canvas.height);
+  img.ctx.drawImage(img.base, 0, 0);
+}
+
+function imgRender() {
+  imgRenderBase();
+  if (img.tool === 'crop' && img.cropRect) imgDrawCropOverlay(img.cropRect);
+}
+
+function imgStyleStroke(ctx) {
+  ctx.strokeStyle = img.color;
+  ctx.fillStyle = img.color;
+  ctx.lineWidth = img.stroke;
+  ctx.lineCap = 'round';
+  ctx.lineJoin = 'round';
+}
+
+function imgDrawArrow(ctx, a, b) {
+  const head = Math.max(12, img.stroke * 3);
+  const ang = Math.atan2(b.y - a.y, b.x - a.x);
+  ctx.beginPath(); ctx.moveTo(a.x, a.y); ctx.lineTo(b.x, b.y); ctx.stroke();
+  ctx.beginPath();
+  ctx.moveTo(b.x, b.y);
+  ctx.lineTo(b.x - head * Math.cos(ang - Math.PI / 6), b.y - head * Math.sin(ang - Math.PI / 6));
+  ctx.lineTo(b.x - head * Math.cos(ang + Math.PI / 6), b.y - head * Math.sin(ang + Math.PI / 6));
+  ctx.closePath(); ctx.fill();
+}
+
+function imgDrawPen(ctx, pts) {
+  if (pts.length < 1) return;
+  imgStyleStroke(ctx);
+  ctx.beginPath(); ctx.moveTo(pts[0].x, pts[0].y);
+  for (let i = 1; i < pts.length; i++) ctx.lineTo(pts[i].x, pts[i].y);
+  ctx.stroke();
+}
+
+function imgPixelate(ctx, x, y, w, h, block) {
+  x = Math.max(0, Math.round(x)); y = Math.max(0, Math.round(y));
+  w = Math.min(img.base.width - x, Math.round(w));
+  h = Math.min(img.base.height - y, Math.round(h));
+  if (w <= 0 || h <= 0) return;
+  const src = ctx.getImageData(x, y, w, h).data;
+  for (let by = 0; by < h; by += block) {
+    for (let bx = 0; bx < w; bx += block) {
+      let r = 0, g = 0, bl = 0, a = 0, n = 0;
+      for (let dy = 0; dy < block && by + dy < h; dy++) {
+        for (let dx = 0; dx < block && bx + dx < w; dx++) {
+          const i = ((by + dy) * w + (bx + dx)) * 4;
+          r += src[i]; g += src[i + 1]; bl += src[i + 2]; a += src[i + 3]; n++;
+        }
+      }
+      ctx.fillStyle = `rgba(${(r / n) | 0},${(g / n) | 0},${(bl / n) | 0},${a / n / 255})`;
+      ctx.fillRect(x + bx, y + by, Math.min(block, w - bx), Math.min(block, h - by));
+    }
+  }
+}
+
+function imgCommitShape(ctx, tool, a, b) {
+  if (tool === 'redact') {
+    const r = imgNormRect(a, b);
+    ctx.fillStyle = '#000';
+    ctx.fillRect(r.x, r.y, r.w, r.h);
+  } else if (tool === 'pixelate') {
+    const r = imgNormRect(a, b);
+    if (r.w > 1 && r.h > 1) imgPixelate(ctx, r.x, r.y, r.w, r.h, img.pixel);
+  } else if (tool === 'rect') {
+    const r = imgNormRect(a, b);
+    imgStyleStroke(ctx);
+    ctx.strokeRect(r.x, r.y, r.w, r.h);
+  } else if (tool === 'arrow') {
+    imgStyleStroke(ctx);
+    imgDrawArrow(ctx, a, b);
+  }
+}
+
+function imgDrawCropOverlay(r) {
+  const ctx = img.ctx, W = img.canvas.width, H = img.canvas.height;
+  ctx.save();
+  ctx.fillStyle = 'rgba(0,0,0,0.5)';
+  ctx.fillRect(0, 0, W, r.y);
+  ctx.fillRect(0, r.y + r.h, W, H - (r.y + r.h));
+  ctx.fillRect(0, r.y, r.x, r.h);
+  ctx.fillRect(r.x + r.w, r.y, W - (r.x + r.w), r.h);
+  ctx.strokeStyle = '#fff';
+  ctx.lineWidth = Math.max(1, W / (img.canvas.getBoundingClientRect().width || W));
+  ctx.strokeRect(r.x, r.y, r.w, r.h);
+  ctx.restore();
+}
+
+/* ── History ── */
+function imgPush() {
+  const snap = img.base.getContext('2d').getImageData(0, 0, img.base.width, img.base.height);
+  img.history = img.history.slice(0, img.hi + 1);
+  img.history.push(snap);
+  if (img.history.length > IMG_HISTORY) img.history.shift();
+  img.hi = img.history.length - 1;
+  imgUpdateHistBtns();
+}
+
+function imgRestore() {
+  const snap = img.history[img.hi];
+  img.base.width = snap.width;
+  img.base.height = snap.height;
+  img.base.getContext('2d').putImageData(snap, 0, 0);
+  imgSyncSize();
+  imgRender();
+  imgUpdateHistBtns();
+}
+
+function imgUpdateHistBtns() {
+  imgEl('img-undo').disabled = img.hi <= 0;
+  imgEl('img-redo').disabled = img.hi >= img.history.length - 1;
+}
+
+function imgUndo() { if (img.hi > 0) { img.hi--; imgRestore(); imgEstimateSize(); } }
+function imgRedo() { if (img.hi < img.history.length - 1) { img.hi++; imgRestore(); imgEstimateSize(); } }
+
+/* ── Sizing ── */
+function imgSyncSize() {
+  img.canvas.width = img.base.width;
+  img.canvas.height = img.base.height;
+  imgEl('img-w').value = img.base.width;
+  imgEl('img-h').value = img.base.height;
+}
+
+/* ── Loading ── */
+function imgIngest(file) {
+  if (!file || !file.type || !file.type.startsWith('image/')) {
+    setError('img-err', 'That is not an image file.');
+    return;
+  }
+  setError('img-err', '');
+  const url = URL.createObjectURL(file);
+  const im = new Image();
+  im.onload = () => { imgLoadImage(im); URL.revokeObjectURL(url); };
+  im.onerror = () => { setError('img-err', 'Could not load that image.'); URL.revokeObjectURL(url); };
+  im.src = url;
+}
+
+function imgLoadImage(im) {
+  let w = im.naturalWidth, h = im.naturalHeight;
+  if (Math.max(w, h) > IMG_MAX_LOAD) {
+    const s = IMG_MAX_LOAD / Math.max(w, h);
+    w = Math.round(w * s); h = Math.round(h * s);
+    showToast(`Large image downscaled to ${w}×${h}`);
+  }
+  img.base = document.createElement('canvas');
+  img.base.width = w; img.base.height = h;
+  img.base.getContext('2d').drawImage(im, 0, 0, w, h);
+
+  img.history = []; img.hi = -1; img.cropRect = null;
+  imgEl('img-placeholder').style.display = 'none';
+  img.canvas.style.display = 'block';
+  imgEl('img-toolbar').style.display = 'flex';
+  imgEl('img-actionbar').style.display = 'flex';
+  imgEl('img-cropbar').style.display = 'none';
+
+  imgSyncSize();
+  imgPush();
+  imgRender();
+  imgEstimateSize();
+}
+
+function imgFileChosen(e) {
+  const f = e.target.files && e.target.files[0];
+  if (f) imgIngest(f);
+}
+
+/* ── Tool selection ── */
+function imgSetTool(t) {
+  img.tool = t;
+  document.querySelectorAll('#img-toolbar .img-tool[data-tool]').forEach(b =>
+    b.classList.toggle('active', b.dataset.tool === t));
+  const colorTool = ['rect', 'arrow', 'pen', 'text'].includes(t);
+  imgEl('img-color-wrap').style.display = colorTool ? 'flex' : 'none';
+  imgEl('img-stroke-wrap').style.display = colorTool ? 'flex' : 'none';
+  imgEl('img-pixel-wrap').style.display = (t === 'pixelate') ? 'flex' : 'none';
+  if (img.canvas) img.canvas.style.cursor = (t === 'text') ? 'text' : 'crosshair';
+  if (t !== 'crop' && img.cropRect) imgCancelCrop();
+  imgRender();
+}
+
+/* ── Pointer drawing ── */
+function imgDown(e) {
+  if (!img.base) return;
+  const p = imgPos(e);
+  if (img.tool === 'text') {
+    const t = prompt('Enter label text:');
+    if (t) {
+      const ctx = img.base.getContext('2d');
+      ctx.fillStyle = img.color;
+      ctx.textBaseline = 'top';
+      ctx.font = `600 ${Math.max(14, img.stroke * 4)}px Inter, sans-serif`;
+      ctx.fillText(t, p.x, p.y);
+      imgPush(); imgRender(); imgEstimateSize();
+    }
+    return;
+  }
+  img.drawing = true;
+  img.start = p;
+  img.penPts = [p];
+  img.canvas.setPointerCapture(e.pointerId);
+}
+
+function imgMove(e) {
+  if (!img.drawing) return;
+  const p = imgPos(e);
+  if (img.tool === 'pen') {
+    img.penPts.push(p);
+    imgRenderBase();
+    imgDrawPen(img.ctx, img.penPts);
+    return;
+  }
+  imgRenderBase();
+  if (img.tool === 'crop') { imgDrawCropOverlay(imgNormRect(img.start, p)); return; }
+  imgCommitShape(img.ctx, img.tool, img.start, p);
+}
+
+function imgUp(e) {
+  if (!img.drawing) return;
+  img.drawing = false;
+  const p = imgPos(e);
+  const ctx = img.base.getContext('2d');
+
+  if (img.tool === 'pen') {
+    if (img.penPts.length > 1) { imgDrawPen(ctx, img.penPts); imgPush(); }
+    imgRender(); imgEstimateSize();
+    return;
+  }
+  if (img.tool === 'crop') {
+    const r = imgNormRect(img.start, p);
+    if (r.w > 4 && r.h > 4) { img.cropRect = r; imgEl('img-cropbar').style.display = 'flex'; }
+    else { img.cropRect = null; imgEl('img-cropbar').style.display = 'none'; }
+    imgRender();
+    return;
+  }
+  const r = imgNormRect(img.start, p);
+  if (r.w < 2 && r.h < 2) { imgRender(); return; }   // ignore stray clicks
+  imgCommitShape(ctx, img.tool, img.start, p);
+  imgPush(); imgRender(); imgEstimateSize();
+}
+
+/* ── Crop / resize ── */
+function imgApplyCrop() {
+  if (!img.cropRect) return;
+  const r = img.cropRect;
+  const nc = document.createElement('canvas');
+  nc.width = Math.round(r.w); nc.height = Math.round(r.h);
+  nc.getContext('2d').drawImage(img.base, r.x, r.y, r.w, r.h, 0, 0, r.w, r.h);
+  img.base = nc;
+  img.cropRect = null;
+  imgEl('img-cropbar').style.display = 'none';
+  imgSyncSize(); imgPush(); imgRender(); imgEstimateSize();
+}
+
+function imgCancelCrop() {
+  img.cropRect = null;
+  imgEl('img-cropbar').style.display = 'none';
+  imgRender();
+}
+
+function imgAspect(which) {
+  if (!img.base || !imgEl('img-aspect').checked) return;
+  const ratio = img.base.width / img.base.height;
+  if (which === 'w') {
+    const w = parseInt(imgEl('img-w').value);
+    if (w > 0) imgEl('img-h').value = Math.round(w / ratio);
+  } else {
+    const h = parseInt(imgEl('img-h').value);
+    if (h > 0) imgEl('img-w').value = Math.round(h * ratio);
+  }
+}
+
+function imgApplyResize() {
+  if (!img.base) return;
+  const w = parseInt(imgEl('img-w').value), h = parseInt(imgEl('img-h').value);
+  if (!w || !h || w < 1 || h < 1) { setError('img-err', 'Enter a valid width and height.'); return; }
+  if (w > IMG_MAX_DIM || h > IMG_MAX_DIM) { setError('img-err', `Max dimension is ${IMG_MAX_DIM}px.`); return; }
+  setError('img-err', '');
+  const nc = document.createElement('canvas');
+  nc.width = w; nc.height = h;
+  nc.getContext('2d').drawImage(img.base, 0, 0, w, h);
+  img.base = nc;
+  imgSyncSize(); imgPush(); imgRender(); imgEstimateSize();
+}
+
+/* ── Export ── */
+function imgQuality() { return parseInt(imgEl('img-quality').value) / 100; }
+
+function imgFormatChange() {
+  const f = imgEl('img-format').value;
+  imgEl('img-quality-wrap').style.display = (f === 'image/png') ? 'none' : 'flex';
+  imgEstimateSize();
+}
+
+function imgToBlob(cb) {
+  const f = imgEl('img-format').value;
+  const q = (f === 'image/png') ? undefined : imgQuality();
+  img.base.toBlob(cb, f, q);
+}
+
+function imgEstimateSize() {
+  imgEl('img-quality-val').textContent = imgEl('img-quality').value;
+  if (!img.base) { imgEl('img-size').textContent = ''; return; }
+  imgToBlob(b => { if (b) imgEl('img-size').textContent = imgHumanSize(b.size); });
+}
+
+function imgExport() {
+  if (!img.base) return;
+  const f = imgEl('img-format').value;
+  const ext = f === 'image/jpeg' ? 'jpg' : f === 'image/webp' ? 'webp' : 'png';
+  imgToBlob(b => {
+    if (!b) { setError('img-err', 'Export failed in this browser.'); return; }
+    const url = URL.createObjectURL(b);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'edited.' + ext;
+    a.click();
+    URL.revokeObjectURL(url);
+    showToast('Downloaded (' + imgHumanSize(b.size) + ')');
+  });
+}
+
+function imgCopy() {
+  if (!img.base) return;
+  if (!window.ClipboardItem || !navigator.clipboard || !navigator.clipboard.write) {
+    showToast('Clipboard image copy not supported here');
+    return;
+  }
+  img.base.toBlob(b => {
+    if (!b) return;
+    navigator.clipboard.write([new ClipboardItem({ 'image/png': b })])
+      .then(() => showToast('Copied to clipboard (PNG)'))
+      .catch(() => showToast('Copy failed — use Download'));
+  }, 'image/png');
+}
+
+function imgReset() {
+  img.base = null; img.history = []; img.hi = -1;
+  img.cropRect = null; img.drawing = false;
+  img.canvas.style.display = 'none';
+  imgEl('img-placeholder').style.display = 'flex';
+  imgEl('img-toolbar').style.display = 'none';
+  imgEl('img-actionbar').style.display = 'none';
+  imgEl('img-cropbar').style.display = 'none';
+  imgEl('img-size').textContent = '';
+  imgEl('img-file').value = '';
+  setError('img-err', '');
+}
+
+/* ── Init ── */
+function imgInit() {
+  img.canvas = imgEl('img-canvas');
+  if (!img.canvas) return;
+  img.ctx = img.canvas.getContext('2d');
+
+  const strokeEl = imgEl('img-stroke');
+  strokeEl.addEventListener('input', () => {
+    img.stroke = parseInt(strokeEl.value);
+    imgEl('img-stroke-val').textContent = strokeEl.value;
+  });
+  const pixelEl = imgEl('img-pixel');
+  pixelEl.addEventListener('input', () => {
+    img.pixel = parseInt(pixelEl.value);
+    imgEl('img-pixel-val').textContent = pixelEl.value;
+  });
+  imgEl('img-color').addEventListener('input', e => { img.color = e.target.value; });
+
+  img.canvas.addEventListener('pointerdown', imgDown);
+  img.canvas.addEventListener('pointermove', imgMove);
+  window.addEventListener('pointerup', imgUp);
+
+  imgEl('img-w').addEventListener('input', () => imgAspect('w'));
+  imgEl('img-h').addEventListener('input', () => imgAspect('h'));
+
+  const stage = imgEl('img-stage'), ph = imgEl('img-placeholder');
+  ['dragenter', 'dragover'].forEach(ev => stage.addEventListener(ev, e => { e.preventDefault(); ph.classList.add('dragover'); }));
+  ['dragleave', 'drop'].forEach(ev => stage.addEventListener(ev, e => { e.preventDefault(); ph.classList.remove('dragover'); }));
+  stage.addEventListener('drop', e => {
+    const f = e.dataTransfer && e.dataTransfer.files && e.dataTransfer.files[0];
+    if (f) imgIngest(f);
+  });
+
+  window.addEventListener('paste', e => {
+    if (!imgEl('tab-img').classList.contains('active')) return;
+    const items = (e.clipboardData && e.clipboardData.items) || [];
+    for (const it of items) {
+      if (it.type && it.type.startsWith('image/')) {
+        const f = it.getAsFile();
+        if (f) { imgIngest(f); e.preventDefault(); }
+        break;
+      }
+    }
+  });
+
+  window.addEventListener('keydown', e => {
+    if (!imgEl('tab-img').classList.contains('active')) return;
+    const k = e.key.toLowerCase();
+    if ((e.ctrlKey || e.metaKey) && k === 'z') { e.preventDefault(); e.shiftKey ? imgRedo() : imgUndo(); }
+    else if ((e.ctrlKey || e.metaKey) && k === 'y') { e.preventDefault(); imgRedo(); }
+  });
+
+  imgSetTool('redact');
+}
+imgInit();

--- a/app.js
+++ b/app.js
@@ -895,6 +895,11 @@ const IMG_HISTORY = 12;      // snapshot cap (memory guard)
 
 function imgEl(id) { return document.getElementById(id); }
 
+// The offscreen base canvas is read back frequently (snapshots, pixelate),
+// so hint the browser to keep it in a CPU-readable buffer. Only affects the
+// first getContext call per canvas; later calls return the same context.
+function imgBaseCtx(c) { return c.getContext('2d', { willReadFrequently: true }); }
+
 function imgHumanSize(n) {
   return n < 1024 ? n + ' B'
     : n < 1048576 ? (n / 1024).toFixed(1) + ' KB'
@@ -1007,7 +1012,7 @@ function imgDrawCropOverlay(r) {
 
 /* ── History ── */
 function imgPush() {
-  const snap = img.base.getContext('2d').getImageData(0, 0, img.base.width, img.base.height);
+  const snap = imgBaseCtx(img.base).getImageData(0, 0, img.base.width, img.base.height);
   img.history = img.history.slice(0, img.hi + 1);
   img.history.push(snap);
   if (img.history.length > IMG_HISTORY) img.history.shift();
@@ -1019,7 +1024,7 @@ function imgRestore() {
   const snap = img.history[img.hi];
   img.base.width = snap.width;
   img.base.height = snap.height;
-  img.base.getContext('2d').putImageData(snap, 0, 0);
+  imgBaseCtx(img.base).putImageData(snap, 0, 0);
   imgSyncSize();
   imgRender();
   imgUpdateHistBtns();
@@ -1064,7 +1069,7 @@ function imgLoadImage(im) {
   }
   img.base = document.createElement('canvas');
   img.base.width = w; img.base.height = h;
-  img.base.getContext('2d').drawImage(im, 0, 0, w, h);
+  imgBaseCtx(img.base).drawImage(im, 0, 0, w, h);
 
   img.history = []; img.hi = -1; img.cropRect = null;
   imgEl('img-placeholder').style.display = 'none';
@@ -1105,7 +1110,7 @@ function imgDown(e) {
   if (img.tool === 'text') {
     const t = prompt('Enter label text:');
     if (t) {
-      const ctx = img.base.getContext('2d');
+      const ctx = imgBaseCtx(img.base);
       ctx.fillStyle = img.color;
       ctx.textBaseline = 'top';
       ctx.font = `600 ${Math.max(14, img.stroke * 4)}px Inter, sans-serif`;
@@ -1138,7 +1143,7 @@ function imgUp(e) {
   if (!img.drawing) return;
   img.drawing = false;
   const p = imgPos(e);
-  const ctx = img.base.getContext('2d');
+  const ctx = imgBaseCtx(img.base);
 
   if (img.tool === 'pen') {
     if (img.penPts.length > 1) { imgDrawPen(ctx, img.penPts); imgPush(); }
@@ -1164,7 +1169,7 @@ function imgApplyCrop() {
   const r = img.cropRect;
   const nc = document.createElement('canvas');
   nc.width = Math.round(r.w); nc.height = Math.round(r.h);
-  nc.getContext('2d').drawImage(img.base, r.x, r.y, r.w, r.h, 0, 0, r.w, r.h);
+  imgBaseCtx(nc).drawImage(img.base, r.x, r.y, r.w, r.h, 0, 0, r.w, r.h);
   img.base = nc;
   img.cropRect = null;
   imgEl('img-cropbar').style.display = 'none';
@@ -1197,7 +1202,7 @@ function imgApplyResize() {
   setError('img-err', '');
   const nc = document.createElement('canvas');
   nc.width = w; nc.height = h;
-  nc.getContext('2d').drawImage(img.base, 0, 0, w, h);
+  imgBaseCtx(nc).drawImage(img.base, 0, 0, w, h);
   img.base = nc;
   imgSyncSize(); imgPush(); imgRender(); imgEstimateSize();
 }

--- a/index.html
+++ b/index.html
@@ -72,6 +72,7 @@
         <button data-tab="timestamp">Timestamp</button>
         <button data-tab="httpstatus">HTTP Status</button>
         <button data-tab="cors">CORS Builder</button>
+        <button data-tab="img">Image Editor</button>
       </div>
     </div>
   </nav>
@@ -624,6 +625,109 @@
           <button class="btn btn-secondary" onclick="copyText('cors-result')">Copy Headers</button>
         </div>
       </div>
+    </div>
+
+    <!-- ═══ Image Redactor ═══ -->
+    <div class="tab-panel" id="tab-img">
+      <div class="panel-title">
+        <span class="icon">🖼</span> Image Editor
+      </div>
+
+      <p class="img-blurb">
+        Redact, annotate, crop and compress screenshots entirely in your browser.
+        Nothing is uploaded, and image metadata (EXIF) is stripped on export.
+      </p>
+
+      <div class="err-msg" id="img-err"></div>
+
+      <!-- Toolbar: appears only once an image is loaded -->
+      <div class="img-toolbar" id="img-toolbar" style="display:none;">
+        <div class="img-tool-group" role="group" aria-label="Tools">
+          <button class="img-tool active" data-tool="redact"   onclick="imgSetTool('redact')"   title="Redact (solid black)">Redact</button>
+          <button class="img-tool"        data-tool="pixelate" onclick="imgSetTool('pixelate')" title="Pixelate / blur region">Pixelate</button>
+          <button class="img-tool"        data-tool="rect"     onclick="imgSetTool('rect')"     title="Rectangle outline">Box</button>
+          <button class="img-tool"        data-tool="arrow"    onclick="imgSetTool('arrow')"    title="Arrow">Arrow</button>
+          <button class="img-tool"        data-tool="pen"      onclick="imgSetTool('pen')"      title="Freehand pen">Pen</button>
+          <button class="img-tool"        data-tool="text"     onclick="imgSetTool('text')"     title="Text label">Text</button>
+          <button class="img-tool"        data-tool="crop"     onclick="imgSetTool('crop')"     title="Crop">Crop</button>
+        </div>
+
+        <div class="img-opt-group">
+          <label class="img-opt" id="img-color-wrap">
+            <span>Color</span>
+            <input type="color" id="img-color" value="#ff3b30">
+          </label>
+          <label class="img-opt" id="img-stroke-wrap">
+            <span>Stroke</span>
+            <input type="range" id="img-stroke" min="1" max="40" value="6">
+            <span class="img-opt-val" id="img-stroke-val">6</span>
+          </label>
+          <label class="img-opt" id="img-pixel-wrap" style="display:none;">
+            <span>Block</span>
+            <input type="range" id="img-pixel" min="4" max="48" value="14">
+            <span class="img-opt-val" id="img-pixel-val">14</span>
+          </label>
+        </div>
+
+        <span class="spacer"></span>
+
+        <div class="img-tool-group">
+          <button class="img-tool" onclick="imgUndo()" id="img-undo" title="Undo (Ctrl+Z)" disabled>↶ Undo</button>
+          <button class="img-tool" onclick="imgRedo()" id="img-redo" title="Redo (Ctrl+Y)" disabled>↷ Redo</button>
+        </div>
+      </div>
+
+      <!-- Action bar: resize + export, kept above the canvas so it stays reachable with tall images -->
+      <div class="img-actionbar" id="img-actionbar" style="display:none;">
+        <div class="img-action-block">
+          <label class="img-opt"><span>W</span><input type="number" id="img-w" class="text-input img-dim" min="1"></label>
+          <label class="img-opt"><span>H</span><input type="number" id="img-h" class="text-input img-dim" min="1"></label>
+          <label class="img-opt img-lock"><input type="checkbox" id="img-aspect" checked> Lock ratio</label>
+          <button class="btn btn-secondary" onclick="imgApplyResize()">Resize</button>
+        </div>
+
+        <span class="spacer"></span>
+
+        <div class="img-action-block">
+          <label class="img-opt">
+            <span>Format</span>
+            <select id="img-format" class="img-select" onchange="imgFormatChange()">
+              <option value="image/png">PNG</option>
+              <option value="image/jpeg">JPEG</option>
+              <option value="image/webp">WebP</option>
+            </select>
+          </label>
+          <label class="img-opt" id="img-quality-wrap" style="display:none;">
+            <span>Quality</span>
+            <input type="range" id="img-quality" min="10" max="100" value="90" oninput="imgEstimateSize()">
+            <span class="img-opt-val" id="img-quality-val">90</span>
+          </label>
+          <span class="img-size" id="img-size"></span>
+          <button class="btn btn-primary" onclick="imgExport()">⬇ Download</button>
+          <button class="btn btn-secondary" onclick="imgCopy()">Copy</button>
+          <button class="btn btn-danger" onclick="imgReset()">Clear</button>
+        </div>
+      </div>
+
+      <!-- Crop apply bar: only visible with a pending crop selection -->
+      <div class="img-cropbar" id="img-cropbar" style="display:none;">
+        <span class="img-crop-note">Selection ready.</span>
+        <button class="btn btn-primary" onclick="imgApplyCrop()">✂ Apply Crop</button>
+        <button class="btn btn-secondary" onclick="imgCancelCrop()">Cancel</button>
+      </div>
+
+      <!-- Stage: placeholder before load, canvas after -->
+      <div class="img-stage" id="img-stage">
+        <div class="img-placeholder" id="img-placeholder">
+          <span class="material-symbols-outlined img-drop-icon">add_photo_alternate</span>
+          <div class="img-drop-title">Drop an image here, paste from clipboard, or</div>
+          <button class="btn btn-primary" onclick="document.getElementById('img-file').click()">Choose file</button>
+          <div class="img-drop-hint">Ctrl/Cmd+V pastes a screenshot directly</div>
+        </div>
+        <canvas id="img-canvas" style="display:none;"></canvas>
+      </div>
+
+      <input type="file" id="img-file" accept="image/*" hidden onchange="imgFileChosen(event)">
     </div>
 
   </div><!-- .content -->

--- a/style.css
+++ b/style.css
@@ -557,3 +557,162 @@ footer {
   font-size: 0.78rem;
   color: var(--muted);
 }
+
+/* ── Image Editor ── */
+.img-blurb {
+  font-size: 0.82rem;
+  color: var(--muted);
+  line-height: 1.6;
+  margin: -8px 0 16px;
+  max-width: 720px;
+}
+
+.img-toolbar,
+.img-actionbar,
+.img-cropbar {
+  display: flex;
+  align-items: center;
+  flex-wrap: wrap;
+  gap: 10px;
+  padding: 10px 12px;
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  margin-bottom: 12px;
+}
+
+.img-cropbar { margin-top: 12px; }
+
+.img-tool-group {
+  display: flex;
+  gap: 4px;
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 3px;
+}
+
+.img-tool {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-family: inherit;
+  font-size: 0.8rem;
+  font-weight: 500;
+  padding: 6px 12px;
+  border-radius: 5px;
+  cursor: pointer;
+  transition: background 0.12s, color 0.12s;
+  white-space: nowrap;
+}
+.img-tool:hover:not(:disabled) { color: var(--text); background: var(--border); }
+.img-tool.active { background: var(--accent); color: #fff; }
+.img-tool:disabled { opacity: 0.4; cursor: not-allowed; }
+
+.img-opt-group,
+.img-action-block {
+  display: flex;
+  align-items: center;
+  gap: 14px;
+  flex-wrap: wrap;
+}
+
+.img-opt {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  font-size: 0.78rem;
+  color: var(--muted);
+  font-weight: 500;
+}
+.img-opt input[type="range"] { width: 90px; }
+.img-opt-val {
+  font-family: var(--mono);
+  color: var(--text);
+  width: 24px;
+  text-align: right;
+  font-size: 0.78rem;
+}
+
+.img-opt input[type="color"] {
+  width: 30px;
+  height: 26px;
+  padding: 0;
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  background: var(--surface2);
+  cursor: pointer;
+}
+.img-opt input[type="color"]::-webkit-color-swatch-wrapper { padding: 2px; }
+.img-opt input[type="color"]::-webkit-color-swatch { border: none; border-radius: 3px; }
+
+.img-lock input[type="checkbox"] { accent-color: var(--accent); cursor: pointer; }
+
+.img-dim { width: 84px; }
+
+.img-select {
+  background: var(--surface2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  padding: 5px 8px;
+  font-size: 0.8rem;
+  cursor: pointer;
+}
+
+.img-size {
+  font-family: var(--mono);
+  font-size: 0.78rem;
+  color: var(--muted);
+  min-width: 60px;
+}
+
+/* Stage */
+.img-stage {
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(45deg, var(--surface2) 25%, transparent 25%),
+    linear-gradient(-45deg, var(--surface2) 25%, transparent 25%),
+    linear-gradient(45deg, transparent 75%, var(--surface2) 75%),
+    linear-gradient(-45deg, transparent 75%, var(--surface2) 75%);
+  background-size: 20px 20px;
+  background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+  background-color: var(--surface);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  min-height: 320px;
+  max-height: 68vh;
+  overflow: auto;
+  padding: 16px;
+}
+
+.img-placeholder {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 12px;
+  color: var(--muted);
+  text-align: center;
+  padding: 40px 20px;
+}
+.img-placeholder.dragover { color: var(--accent); }
+.img-drop-icon { font-size: 46px; opacity: 0.7; }
+.img-drop-title { font-size: 0.9rem; }
+.img-drop-hint { font-size: 0.76rem; opacity: 0.7; }
+
+#img-canvas {
+  max-width: 100%;
+  height: auto;
+  display: block;
+  box-shadow: 0 2px 14px rgba(0,0,0,0.35);
+  touch-action: none;
+  cursor: crosshair;
+}
+
+.img-crop-note { font-size: 0.8rem; color: var(--muted); margin-right: auto; }
+
+@media (max-width: 760px) {
+  .img-opt input[type="range"] { width: 64px; }
+}


### PR DESCRIPTION
## Summary

Adds a fully client-side **Image Editor** tool under the **Utilities** category. Like every other tool in this toolkit, it runs entirely in the browser with no build step, no dependencies, and no network calls.

Built for the common Customer Success task of prepping screenshots for tickets: redact sensitive data, annotate to explain an issue, and crop/resize/compress to fit attachment limits.

<img width="1492" height="858" alt="Screenshot 2026-07-06 at 22 24 22" src="https://github.com/user-attachments/assets/f2cbb1e5-7a29-4b4c-bb38-6749d6622a80" />


## Features

- **Redact** — solid black boxes, baked into the bitmap on commit so they are not recoverable overlays. Plus **pixelate** with adjustable block size.
- **Annotate** — box, arrow, freehand pen, and text label, with a color picker and stroke-width control. Full undo/redo (Ctrl+Z / Ctrl+Shift+Z / Ctrl+Y).
- **Crop / resize / compress** — drag-to-crop with a dim overlay, W/H resize with aspect lock, and export to PNG / JPEG / WebP with a quality slider and live output-size estimate.
- **Input** — file picker, drag-drop, or clipboard paste (Ctrl/Cmd+V).
- **Output** — Download (always works) and Copy-to-clipboard (Chromium).

## Notes

- **EXIF is stripped on export** because the image is re-encoded through `<canvas>`.
- Large images auto-downscale to 4000px; manual resize is capped at 8000px.
- Control bars (tools + resize/export) sit **above** the canvas, and the canvas stage scrolls internally (`max-height: 68vh`), so all buttons stay reachable no matter how tall the image is.
- Undo/redo uses base-canvas snapshots, capped at 12 to bound memory.

## Testing

Verified end-to-end in Chromium (Playwright), zero console errors:
- Redaction bakes true black pixels (destructive), surrounding pixels untouched.
- Undo restores original pixels and disables at history start; redo re-applies.
- Real mouse-drag path: coordinate scaling correct, redaction lands where drawn.
- Crop (200x100 -> 40x40), resize (-> 80x80), JPEG export produces a valid blob, pixelate runs clean.
- Layout: with a 600x3000 image loaded, the Download button stays in the viewport and the stage scrolls internally.

## Files

- `index.html` — nav button + tool panel
- `app.js` — self-contained image editor module
- `style.css` — toolbar and canvas-stage styles
- `README.md` — tool table + technical notes
